### PR TITLE
Modify parser to parse logs with Botnet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "ScalaApacheAccessLogParser"
 
 version := "1.0"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.10.4"
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 

--- a/src/main/scala/AccessLogRecord.scala
+++ b/src/main/scala/AccessLogRecord.scala
@@ -4,6 +4,7 @@ package com.alvinalexander.accesslogparser
  * @see http://httpd.apache.org/docs/2.2/logs.html for details
  */
 case class AccessLogRecord (
+	botnet: String,                  // string or empty
     clientIpAddress: String,         // should be an ip address, but may also be the hostname if hostname-lookups are enabled
     rfc1413ClientIdentity: String,   // typically `-`
     remoteUser: String,              // typically `-`

--- a/src/test/scala/AccessLogRecordSpec.scala
+++ b/src/test/scala/AccessLogRecordSpec.scala
@@ -20,6 +20,7 @@ class ApacheCombinedAccessLogRecordSpec extends FunSpec with BeforeAndAfter with
           val parser = new AccessLogParser
           val rec = parser.parseRecord(records(0))
           println("IP ADDRESS: " + rec.get.clientIpAddress)
+          println("BOTNET: " + rec.get.botnet)
           Then("parsing record(0) should not return None")
               assert(rec != None)
           And("the ip address should be correct")
@@ -40,6 +41,39 @@ class ApacheCombinedAccessLogRecordSpec extends FunSpec with BeforeAndAfter with
               assert(rec.get.referer == "http://www.google.co.in/search?hl=en&client=firefox-a&rlz=1R1GGGL_en___IN337&hs=F0W&q=reading+data+from+file+in+java&btnG=Search&meta=&aq=0&oq=reading+data+")          
           And("user agent")
               assert(rec.get.userAgent == "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.11) Gecko/2009060215 Firefox/3.0.11 GTB5")  
+      }
+  }
+
+  describe("Testing the access log record with botnet ...") {
+      it("the data fields should be correct") {
+          Given("the first sample log record")
+          records = SampleCombinedAccessLogRecords.botnetRecord
+          val parser = new AccessLogParser
+          val rec = parser.parseRecord(records(0))
+          println("IP ADDRESS: " + rec.get.clientIpAddress)
+          println("BOTNET: " + rec.get.botnet)
+          Then("parsing record(0) should not return None")
+              assert(rec != None)
+          And("botnet")
+              assert(rec.get.botnet == "Expiro")
+          And("the ip address should be correct")
+              assert(rec.get.clientIpAddress == "5.102.63.11")              
+          And("client identity")
+              assert(rec.get.rfc1413ClientIdentity == "-")          
+          And("remote user")
+              assert(rec.get.remoteUser == "-")          
+          And("date/time")
+              assert(rec.get.dateTime == "[31/Jan/2014:10:06:55 +0000]")          
+          And("request")
+              assert(rec.get.request == "GET /?f=x HTTP/1.1")          
+          And("status code should be 200")
+              assert(rec.get.httpStatusCode == "200")
+          And("bytes sent should be 3594")
+              assert(rec.get.bytesSent == "3594")
+          And("referer")
+              assert(rec.get.referer == "http://www.foo.it/foo.php")          
+          And("user agent")
+              assert(rec.get.userAgent == "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)")  
       }
   }
   

--- a/src/test/scala/SampleData.scala
+++ b/src/test/scala/SampleData.scala
@@ -16,6 +16,12 @@ object SampleCombinedAccessLogRecords {
 66.249.70.10 - - [23/Feb/2014:03:21:59 -0700] "GET /blog/post/java/how-load-multiple-spring-context-files-standalone/ HTTP/1.0" 301 - "-" "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 """.split("\n").filter(_ != "")
 
+  val botnetRecord = """
+  Expiro 5.102.63.11 - - [31/Jan/2014:10:06:55 +0000] "GET /?f=x HTTP/1.1" 200 3594 "http://www.foo.it/foo.php" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)"
+  Pandora 5.102.63.11 - - [31/Jan/2014:10:06:55 +0000] "GET /?f=x HTTP/1.1" 200 3594 "http://www.foo.it/foo.php" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)"
+  FakeM 5.102.63.11 - - [31/Jan/2014:10:06:55 +0000] "GET /?f=x HTTP/1.1" 200 3594 "http://www.foo.it/foo.php" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)"
+  Qakbot 5.102.63.11 - - [31/Jan/2014:10:06:55 +0000] "GET /?f=x HTTP/1.1" 200 3594 "http://www.foo.it/foo.php" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)"
+  """.split("\n").filter(_ !="")
 
 }
 


### PR DESCRIPTION
To parse logs like: 

```
Expiro 5.102.63.11 - - [31/Jan/2014:10:06:55 +0000] "GET /?f=x HTTP/1.1" 200 3594 "http://www.foo.it/foo.php" "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; .NET4.0E; InfoPath.2)"
```

without any error. 
If logs do not contain any botnet, then it'll return `-` for Botnet. 
